### PR TITLE
Initial Arch Linux PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,36 @@
+pkgname=nanoclj-git
+pkgver=r604.97c66d9
+pkgrel=1
+pkgdesc="A tiny Clojure interpreter"
+arch=('x86_64')
+url="https://github.com/rekola/nanoclj"
+license=('custom:nanoclj')
+depends=('libsixel' 'shapelib' 'pcre2' 'libutf8proc' 'cairo' 'libcurl-gnutls' 'libxml2' 'zlib')
+options=()
+install=
+source=("git+https://github.com/rekola/nanoclj")
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/nanoclj"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+build() {
+	cd "$srcdir/nanoclj"
+  mkdir -p build
+  cd build 
+  cmake .. 
+  make
+}
+
+package() {
+	cd "$srcdir/nanoclj"
+	install -Dm755 "$srcdir/nanoclj/build/nanoclj" "$pkgdir/usr/bin/nanoclj"
+  install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  cd build
+  for f in *.clj; do
+     install -Dm644 ${f} "$pkgdir/usr/share/nanoclj/${f}"
+  done
+}

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ cmake ..
 make
 ```
 
+### Arch Linux PKGBUILD
+
+```
+curl https://raw.githubusercontent.com/rekola/nanoclj/main/PKGBUILD -O
+makepkg -si
+```
+
 ### Windows
 
 Windows support is in progress.


### PR DESCRIPTION
Adds a PKGBUILD users of Arch Linux (and derivatives) can use to easily package nanoclj for their systems.
It will not work (meaning, the package is built and installed but the binary does not function) until nanoclj is updated to look for the *.clj files in /usr/share/nanoclj